### PR TITLE
Lesson06 profile and performance

### DIFF
--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/codecomparison.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/codecomparison.txt
@@ -1,0 +1,40 @@
+Refactored code snippit with four runtimes:
+
+starttime = time.time()
+for new in new_ones:
+    try:
+        year_count[(lambda x: new[0][6:] if new[0][6:] != '2018' else '2017')(new)] += 1
+    except KeyError:
+        continue
+endtime = time.time()
+print(f"time: {endtime - starttime}")
+
+time: 0.68715500831604
+time: 0.7559976577758789
+time: 0.6761574745178223
+time: 0.6811888217926025
+
+
+Original code snippit with four runtimes:
+
+starttime = time.time()
+for new in new_ones:
+    if new[0][6:] == '2013':
+        year_count["2013"] += 1
+    if new[0][6:] == '2014':
+        year_count["2014"] += 1
+    if new[0][6:] == '2015':
+        year_count["2015"] += 1
+    if new[0][6:] == '2016':
+        year_count["2016"] += 1
+    if new[0][6:] == '2017':
+        year_count["2017"] += 1
+    if new[0][6:] == '2018':
+        year_count["2017"] += 1
+endtime = time.time()
+print(f"time: {endtime - starttime}")
+
+time: 0.7200698852539062
+time: 0.7051050662994385
+time: 0.8367605209350586
+time: 0.7764654159545898

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodfirst.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodfirst.txt
@@ -1,0 +1,145 @@
+DESKTOP-I9H7MOT:assignment motia$ python -m cProfile good_perf.py
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+         1044476 function calls (1044459 primitive calls) in 5.759 seconds
+
+   Ordered by: standard name
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+      8/2    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+       45    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:576(module_from_spec)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+      5/2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap>:663(_load_unlocked)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:740(create_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        5    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap>:882(_find_spec)
+      5/2    0.000    0.000    0.005    0.002 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      5/2    0.000    0.000    0.005    0.002 <frozen importlib._bootstrap>:978(_find_and_load)
+       10    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        8    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        8    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:722(exec_module)
+       12    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        2    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:793(get_code)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+        1    0.000    0.000    0.000    0.000 _bootlocale.py:11(getpreferredencoding)
+        1    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
+    21647    0.016    0.000    0.360    0.000 cp1252.py:22(decode)
+        1    0.000    0.000    0.000    0.000 csv.py:131(DictWriter)
+        1    0.000    0.000    0.000    0.000 csv.py:166(Sniffer)
+        1    0.000    0.000    0.000    0.000 csv.py:24(Dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:4(<module>)
+        1    0.000    0.000    0.000    0.000 csv.py:55(excel)
+        1    0.000    0.000    0.000    0.000 csv.py:65(excel_tab)
+        1    0.000    0.000    0.000    0.000 csv.py:70(unix_dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:81(DictReader)
+        1    0.000    0.000    0.000    0.000 datetime.py:1081(tzinfo)
+        1    0.000    0.000    0.000    0.000 datetime.py:1151(time)
+        2    0.000    0.000    0.000    0.000 datetime.py:1176(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:1488(datetime)
+        3    0.000    0.000    0.000    0.000 datetime.py:1496(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:2097(timezone)
+        3    0.000    0.000    0.000    0.000 datetime.py:2117(_create)
+       35    0.000    0.000    0.000    0.000 datetime.py:378(_check_int_field)
+        5    0.000    0.000    0.000    0.000 datetime.py:395(_check_date_fields)
+        3    0.000    0.000    0.000    0.000 datetime.py:40(_days_before_year)
+        5    0.000    0.000    0.000    0.000 datetime.py:408(_check_time_fields)
+        5    0.000    0.000    0.000    0.000 datetime.py:425(_check_tzinfo_arg)
+        5    0.000    0.000    0.000    0.000 datetime.py:45(_days_in_month)
+        1    0.000    0.000    0.000    0.000 datetime.py:453(timedelta)
+        9    0.000    0.000    0.000    0.000 datetime.py:472(__new__)
+        1    0.000    0.000    0.001    0.001 datetime.py:5(<module>)
+        1    0.000    0.000    0.000    0.000 datetime.py:645(__neg__)
+        1    0.000    0.000    0.000    0.000 datetime.py:773(date)
+        2    0.000    0.000    0.000    0.000 datetime.py:803(__new__)
+        1    0.000    0.000    5.759    5.759 good_perf.py:4(<module>)
+        1    0.098    0.098    5.754    5.754 good_perf.py:52(main)
+        1    5.191    5.191    5.656    5.656 good_perf.py:9(analyze)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFE07578D30}
+    21647    0.343    0.000    0.343    0.000 {built-in method _codecs.charmap_decode}
+        1    0.000    0.000    0.000    0.000 {built-in method _csv.reader}
+        3    0.000    0.000    0.000    0.000 {built-in method _csv.register_dialect}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.create_builtin}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        5    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        1    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+       13    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+        5    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+      3/1    0.000    0.000    5.759    5.759 {built-in method builtins.exec}
+       24    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+       31    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+      171    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+        6    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+        1    0.000    0.000    0.000    0.000 {built-in method io.open}
+        2    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        6    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        2    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+       12    0.002    0.000    0.002    0.000 {built-in method nt.stat}
+  1000012    0.105    0.000    0.105    0.000 {method 'append' of 'list' objects}
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        2    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+       10    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+       44    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 {method 'read' of '_io.FileIO' objects}
+       22    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        4    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+       84    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 {method 'setter' of 'property' objects}

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodfourth.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodfourth.txt
@@ -1,0 +1,147 @@
+DESKTOP-I9H7MOT:assignment motia$ python -m cProfile good_perf_refact.py
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+         3044477 function calls (3044460 primitive calls) in 2.955 seconds
+
+   Ordered by: standard name
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+      8/2    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+       45    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:576(module_from_spec)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+      5/2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap>:663(_load_unlocked)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:740(create_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        5    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap>:882(_find_spec)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:978(_find_and_load)
+       10    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        8    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        8    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:722(exec_module)
+       12    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        2    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:793(get_code)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+        1    0.000    0.000    0.000    0.000 _bootlocale.py:11(getpreferredencoding)
+        1    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
+    21647    0.012    0.000    0.322    0.000 cp1252.py:22(decode)
+        1    0.000    0.000    0.000    0.000 csv.py:131(DictWriter)
+        1    0.000    0.000    0.000    0.000 csv.py:166(Sniffer)
+        1    0.000    0.000    0.000    0.000 csv.py:24(Dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:4(<module>)
+        1    0.000    0.000    0.000    0.000 csv.py:55(excel)
+        1    0.000    0.000    0.000    0.000 csv.py:65(excel_tab)
+        1    0.000    0.000    0.000    0.000 csv.py:70(unix_dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:81(DictReader)
+        1    0.000    0.000    0.000    0.000 datetime.py:1081(tzinfo)
+        1    0.000    0.000    0.000    0.000 datetime.py:1151(time)
+        2    0.000    0.000    0.000    0.000 datetime.py:1176(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:1488(datetime)
+        3    0.000    0.000    0.000    0.000 datetime.py:1496(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:2097(timezone)
+        3    0.000    0.000    0.000    0.000 datetime.py:2117(_create)
+       35    0.000    0.000    0.000    0.000 datetime.py:378(_check_int_field)
+        5    0.000    0.000    0.000    0.000 datetime.py:395(_check_date_fields)
+        3    0.000    0.000    0.000    0.000 datetime.py:40(_days_before_year)
+        5    0.000    0.000    0.000    0.000 datetime.py:408(_check_time_fields)
+        5    0.000    0.000    0.000    0.000 datetime.py:425(_check_tzinfo_arg)
+        5    0.000    0.000    0.000    0.000 datetime.py:45(_days_in_month)
+        1    0.000    0.000    0.000    0.000 datetime.py:453(timedelta)
+        9    0.000    0.000    0.000    0.000 datetime.py:472(__new__)
+        1    0.000    0.000    0.001    0.001 datetime.py:5(<module>)
+        1    0.000    0.000    0.000    0.000 datetime.py:645(__neg__)
+        1    0.000    0.000    0.000    0.000 datetime.py:773(date)
+        2    0.000    0.000    0.000    0.000 datetime.py:803(__new__)
+  1000000    0.276    0.000    0.276    0.000 good_perf_refact.py:36(<lambda>)
+        1    0.000    0.000    2.955    2.955 good_perf_refact.py:4(<module>)
+        1    0.000    0.000    2.951    2.951 good_perf_refact.py:48(main)
+        1    1.867    1.867    2.951    2.951 good_perf_refact.py:9(analyze)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFEFEBD8D30}
+    21647    0.310    0.000    0.310    0.000 {built-in method _codecs.charmap_decode}
+        3    0.000    0.000    0.000    0.000 {built-in method _csv.register_dialect}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.create_builtin}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        5    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        1    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+       13    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+        5    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+      3/1    0.000    0.000    2.955    2.955 {built-in method builtins.exec}
+       24    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+       31    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+      171    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+        6    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+        1    0.000    0.000    0.000    0.000 {built-in method io.open}
+        2    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        6    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        2    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+       12    0.002    0.000    0.002    0.000 {built-in method nt.stat}
+       12    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        2    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+       10    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+       44    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 {method 'read' of '_io.FileIO' objects}
+       22    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        4    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+       84    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 {method 'setter' of 'property' objects}
+  1000001    0.373    0.000    0.373    0.000 {method 'split' of 'str' objects}
+  1000001    0.112    0.000    0.112    0.000 {method 'strip' of 'str' objects}

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodsecond.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodsecond.txt
@@ -1,0 +1,146 @@
+DESKTOP-I9H7MOT:assignment motia$ python -m cProfile good_perf.py
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+         2044476 function calls (2044459 primitive calls) in 5.014 seconds
+
+   Ordered by: standard name
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+      8/2    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+       45    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:576(module_from_spec)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+      5/2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap>:663(_load_unlocked)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:740(create_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        5    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap>:882(_find_spec)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:978(_find_and_load)
+       10    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        8    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        8    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:722(exec_module)
+       12    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        2    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:793(get_code)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+        1    0.000    0.000    0.000    0.000 _bootlocale.py:11(getpreferredencoding)
+        1    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
+    21647    0.011    0.000    0.326    0.000 cp1252.py:22(decode)
+        1    0.000    0.000    0.000    0.000 csv.py:131(DictWriter)
+        1    0.000    0.000    0.000    0.000 csv.py:166(Sniffer)
+        1    0.000    0.000    0.000    0.000 csv.py:24(Dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:4(<module>)
+        1    0.000    0.000    0.000    0.000 csv.py:55(excel)
+        1    0.000    0.000    0.000    0.000 csv.py:65(excel_tab)
+        1    0.000    0.000    0.000    0.000 csv.py:70(unix_dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:81(DictReader)
+        1    0.000    0.000    0.000    0.000 datetime.py:1081(tzinfo)
+        1    0.000    0.000    0.000    0.000 datetime.py:1151(time)
+        2    0.000    0.000    0.000    0.000 datetime.py:1176(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:1488(datetime)
+        3    0.000    0.000    0.000    0.000 datetime.py:1496(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:2097(timezone)
+        3    0.000    0.000    0.000    0.000 datetime.py:2117(_create)
+       35    0.000    0.000    0.000    0.000 datetime.py:378(_check_int_field)
+        5    0.000    0.000    0.000    0.000 datetime.py:395(_check_date_fields)
+        3    0.000    0.000    0.000    0.000 datetime.py:40(_days_before_year)
+        5    0.000    0.000    0.000    0.000 datetime.py:408(_check_time_fields)
+        5    0.000    0.000    0.000    0.000 datetime.py:425(_check_tzinfo_arg)
+        5    0.000    0.000    0.000    0.000 datetime.py:45(_days_in_month)
+        1    0.000    0.000    0.000    0.000 datetime.py:453(timedelta)
+        9    0.000    0.000    0.000    0.000 datetime.py:472(__new__)
+        1    0.000    0.000    0.001    0.001 datetime.py:5(<module>)
+        1    0.000    0.000    0.000    0.000 datetime.py:645(__neg__)
+        1    0.000    0.000    0.000    0.000 datetime.py:773(date)
+        2    0.000    0.000    0.000    0.000 datetime.py:803(__new__)
+        1    4.229    4.229    4.926    4.926 good_perf.py:10(analyze)
+  1000000    0.282    0.000    0.282    0.000 good_perf.py:37(<lambda>)
+        1    0.000    0.000    5.014    5.014 good_perf.py:4(<module>)
+        1    0.084    0.084    5.010    5.010 good_perf.py:48(main)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFE07578D30}
+    21647    0.315    0.000    0.315    0.000 {built-in method _codecs.charmap_decode}
+        1    0.000    0.000    0.000    0.000 {built-in method _csv.reader}
+        3    0.000    0.000    0.000    0.000 {built-in method _csv.register_dialect}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.create_builtin}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        5    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        1    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+       13    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+        5    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+      3/1    0.000    0.000    5.014    5.014 {built-in method builtins.exec}
+       24    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+       31    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+      171    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+        6    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+        1    0.000    0.000    0.000    0.000 {built-in method io.open}
+        2    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        6    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        2    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+       12    0.002    0.000    0.002    0.000 {built-in method nt.stat}
+  1000012    0.088    0.000    0.088    0.000 {method 'append' of 'list' objects}
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        2    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+       10    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+       44    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 {method 'read' of '_io.FileIO' objects}
+       22    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        4    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+       84    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 {method 'setter' of 'property' objects}

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodthird.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultgoodthird.txt
@@ -1,0 +1,146 @@
+DESKTOP-I9H7MOT:assignment motia$ python -m cProfile good_perf.py
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+         1044476 function calls (1044459 primitive calls) in 4.487 seconds
+
+   Ordered by: standard name
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+      8/2    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+       45    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:576(module_from_spec)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+      5/2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap>:663(_load_unlocked)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:740(create_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        5    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap>:882(_find_spec)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:978(_find_and_load)
+       10    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        8    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        8    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:722(exec_module)
+       12    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        2    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:793(get_code)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+        1    0.000    0.000    0.000    0.000 _bootlocale.py:11(getpreferredencoding)
+        1    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
+    21647    0.010    0.000    0.319    0.000 cp1252.py:22(decode)
+        1    0.000    0.000    0.000    0.000 csv.py:131(DictWriter)
+        1    0.000    0.000    0.000    0.000 csv.py:166(Sniffer)
+        1    0.000    0.000    0.000    0.000 csv.py:24(Dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:4(<module>)
+        1    0.000    0.000    0.000    0.000 csv.py:55(excel)
+        1    0.000    0.000    0.000    0.000 csv.py:65(excel_tab)
+        1    0.000    0.000    0.000    0.000 csv.py:70(unix_dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:81(DictReader)
+        1    0.000    0.000    0.000    0.000 datetime.py:1081(tzinfo)
+        1    0.000    0.000    0.000    0.000 datetime.py:1151(time)
+        2    0.000    0.000    0.000    0.000 datetime.py:1176(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:1488(datetime)
+        3    0.000    0.000    0.000    0.000 datetime.py:1496(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:2097(timezone)
+        3    0.000    0.000    0.000    0.000 datetime.py:2117(_create)
+       35    0.000    0.000    0.000    0.000 datetime.py:378(_check_int_field)
+        5    0.000    0.000    0.000    0.000 datetime.py:395(_check_date_fields)
+        3    0.000    0.000    0.000    0.000 datetime.py:40(_days_before_year)
+        5    0.000    0.000    0.000    0.000 datetime.py:408(_check_time_fields)
+        5    0.000    0.000    0.000    0.000 datetime.py:425(_check_tzinfo_arg)
+        5    0.000    0.000    0.000    0.000 datetime.py:45(_days_in_month)
+        1    0.000    0.000    0.000    0.000 datetime.py:453(timedelta)
+        9    0.000    0.000    0.000    0.000 datetime.py:472(__new__)
+        1    0.000    0.000    0.001    0.001 datetime.py:5(<module>)
+        1    0.000    0.000    0.000    0.000 datetime.py:645(__neg__)
+        1    0.000    0.000    0.000    0.000 datetime.py:773(date)
+        2    0.000    0.000    0.000    0.000 datetime.py:803(__new__)
+        1    3.889    3.889    4.483    4.483 good_perf.py:10(analyze)
+  1000000    0.274    0.000    0.274    0.000 good_perf.py:35(<lambda>)
+        1    0.000    0.000    4.487    4.487 good_perf.py:4(<module>)
+        1    0.000    0.000    4.483    4.483 good_perf.py:61(main)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFE07578D30}
+    21647    0.309    0.000    0.309    0.000 {built-in method _codecs.charmap_decode}
+        1    0.000    0.000    0.000    0.000 {built-in method _csv.reader}
+        3    0.000    0.000    0.000    0.000 {built-in method _csv.register_dialect}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.create_builtin}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        5    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        1    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+       13    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+        5    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+      3/1    0.000    0.000    4.487    4.487 {built-in method builtins.exec}
+       24    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+       31    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+      171    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+        6    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+        1    0.000    0.000    0.000    0.000 {built-in method io.open}
+        2    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        6    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        2    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+       12    0.002    0.000    0.002    0.000 {built-in method nt.stat}
+       12    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        2    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+       10    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+       44    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 {method 'read' of '_io.FileIO' objects}
+       22    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        4    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+       84    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 {method 'setter' of 'property' objects}

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultpoor.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/cprofileresultpoor.txt
@@ -1,0 +1,145 @@
+DESKTOP-I9H7MOT:assignment motia$ python -m cProfile poor_perf.py
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+         1087775 function calls (1087758 primitive calls) in 8.564 seconds
+
+   Ordered by: standard name
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+      8/2    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+       45    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:576(module_from_spec)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+      5/2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap>:663(_load_unlocked)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:740(create_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        5    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap>:882(_find_spec)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      5/2    0.000    0.000    0.004    0.002 <frozen importlib._bootstrap>:978(_find_and_load)
+       10    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        8    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        8    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:722(exec_module)
+       12    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        2    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:793(get_code)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+        2    0.000    0.000    0.000    0.000 _bootlocale.py:11(getpreferredencoding)
+        2    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
+    43294    0.023    0.000    0.648    0.000 cp1252.py:22(decode)
+        1    0.000    0.000    0.000    0.000 csv.py:131(DictWriter)
+        1    0.000    0.000    0.000    0.000 csv.py:166(Sniffer)
+        1    0.000    0.000    0.000    0.000 csv.py:24(Dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:4(<module>)
+        1    0.000    0.000    0.000    0.000 csv.py:55(excel)
+        1    0.000    0.000    0.000    0.000 csv.py:65(excel_tab)
+        1    0.000    0.000    0.000    0.000 csv.py:70(unix_dialect)
+        1    0.000    0.000    0.000    0.000 csv.py:81(DictReader)
+        1    0.000    0.000    0.000    0.000 datetime.py:1081(tzinfo)
+        1    0.000    0.000    0.000    0.000 datetime.py:1151(time)
+        2    0.000    0.000    0.000    0.000 datetime.py:1176(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:1488(datetime)
+        3    0.000    0.000    0.000    0.000 datetime.py:1496(__new__)
+        1    0.000    0.000    0.000    0.000 datetime.py:2097(timezone)
+        3    0.000    0.000    0.000    0.000 datetime.py:2117(_create)
+       35    0.000    0.000    0.000    0.000 datetime.py:378(_check_int_field)
+        5    0.000    0.000    0.000    0.000 datetime.py:395(_check_date_fields)
+        3    0.000    0.000    0.000    0.000 datetime.py:40(_days_before_year)
+        5    0.000    0.000    0.000    0.000 datetime.py:408(_check_time_fields)
+        5    0.000    0.000    0.000    0.000 datetime.py:425(_check_tzinfo_arg)
+        5    0.000    0.000    0.000    0.000 datetime.py:45(_days_in_month)
+        1    0.000    0.000    0.000    0.000 datetime.py:453(timedelta)
+        9    0.000    0.000    0.000    0.000 datetime.py:472(__new__)
+        1    0.000    0.000    0.001    0.001 datetime.py:5(<module>)
+        1    0.000    0.000    0.000    0.000 datetime.py:645(__neg__)
+        1    0.000    0.000    0.000    0.000 datetime.py:773(date)
+        2    0.000    0.000    0.000    0.000 datetime.py:803(__new__)
+        1    0.000    0.000    8.564    8.564 poor_perf.py:4(<module>)
+        1    0.090    0.090    8.560    8.560 poor_perf.py:59(main)
+        1    7.727    7.727    8.470    8.470 poor_perf.py:9(analyze)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFFA3358D30}
+    43294    0.624    0.000    0.624    0.000 {built-in method _codecs.charmap_decode}
+        2    0.000    0.000    0.000    0.000 {built-in method _csv.reader}
+        3    0.000    0.000    0.000    0.000 {built-in method _csv.register_dialect}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.create_builtin}
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        5    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        2    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+       13    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+        5    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+      3/1    0.000    0.000    8.564    8.564 {built-in method builtins.exec}
+       24    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+       31    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+      171    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+        6    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+        2    0.001    0.000    0.001    0.000 {built-in method io.open}
+        2    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        6    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        2    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+       12    0.002    0.000    0.002    0.000 {built-in method nt.stat}
+  1000012    0.095    0.000    0.095    0.000 {method 'append' of 'list' objects}
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        2    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+       10    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+       44    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 {method 'read' of '_io.FileIO' objects}
+       22    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        4    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+       84    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 {method 'setter' of 'property' objects}

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/good_perf_refact.py
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/good_perf_refact.py
@@ -1,0 +1,54 @@
+"""
+Analyze module with performance improvements
+
+"""
+
+import datetime
+
+def analyze(filename):
+    """ Analyze the file for specific data """
+
+    start = datetime.datetime.now()
+    found = 0
+
+    year_count = {
+        "2013": 0,
+        "2014": 0,
+        "2015": 0,
+        "2016": 0,
+        "2017": 0,
+        "2018": 0
+    }
+
+    with open(filename) as csvfile:
+
+        for line in csvfile:
+            lrow = list(line.strip().split(','))
+
+            if "ao" in lrow[6]:
+                found += 1
+
+            if lrow[5] > '00/00/2012':
+                try:
+                    year_count[
+                        (lambda x: lrow[5][6:] if lrow[5][6:] != '2018' else '2017')(lrow)
+                        ] += 1
+                except KeyError:
+                    continue
+
+        print(year_count)
+        print(f"'ao' was found {found} times")
+        end = datetime.datetime.now()
+
+    return (start, end, year_count, found)
+
+
+def main():
+    """ Main to call function """
+
+    filename = "data/exercise.csv"
+    analyze(filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/pstatsgoodrefact.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/pstatsgoodrefact.txt
@@ -1,0 +1,146 @@
+[master=]
+DESKTOP-I9H7MOT:assignment motia$ python -m cProfile -s cumulative -o profoutgood good_perf_refact.py
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+[master=]
+DESKTOP-I9H7MOT:assignment motia$ python -m pstats profoutgood
+Welcome to the profile statistics browser.
+profoutgood% sort cumtime
+profoutgood% reverse
+profoutgood% stats
+Sun Feb 17 09:51:07 2019    profoutgood
+
+         3044114 function calls (3044103 primitive calls) in 2.921 seconds
+
+   Ordered by: cumulative time
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        1    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+       11    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\codecs.py:260(__init__)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        1    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+        3    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+       11    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        3    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+        6    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+        3    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1081(tzinfo)
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:425(_check_tzinfo_arg)
+       12    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+        6    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:45(_days_in_month)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+       12    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
+        1    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+       12    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        3    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:2117(_create)
+        3    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:40(_days_before_year)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFEE8C88D30}
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+        1    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        3    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+       42    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+       22    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1151(time)
+       23    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+        1    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:773(date)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       14    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1488(datetime)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\_bootlocale.py:11(getpreferredencoding)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+       16    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+       35    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:378(_check_int_field)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+        2    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:803(__new__)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:645(__neg__)
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+        2    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1176(__new__)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:408(_check_time_fields)
+        6    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+      164    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:395(_check_date_fields)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:2097(timezone)
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        3    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1496(__new__)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:453(timedelta)
+        1    0.000    0.000    0.000    0.000 {method 'read' of '_io.FileIO' objects}
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.create_builtin}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:740(create_module)
+        9    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:472(__new__)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:576(module_from_spec)
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        1    0.000    0.000    0.000    0.000 {built-in method io.open}
+        1    0.000    0.000    0.000    0.000 {built-in method marshal.loads}
+        1    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+        1    0.000    0.000    0.001    0.001 D:\Python_3.7.0\lib\datetime.py:5(<module>)
+      5/1    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+        1    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:793(get_code)
+        4    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+        1    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        1    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        6    0.001    0.000    0.001    0.000 {built-in method nt.stat}
+        6    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        3    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap>:882(_find_spec)
+        1    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap_external>:722(exec_module)
+      3/1    0.000    0.000    0.001    0.001 <frozen importlib._bootstrap>:663(_load_unlocked)
+      3/1    0.000    0.000    0.002    0.002 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      3/1    0.000    0.000    0.003    0.003 <frozen importlib._bootstrap>:978(_find_and_load)
+  1000001    0.115    0.000    0.115    0.000 {method 'strip' of 'str' objects}
+  1000000    0.270    0.000    0.270    0.000 good_perf_refact.py:34(<lambda>)
+    21647    0.305    0.000    0.305    0.000 {built-in method _codecs.charmap_decode}
+    21647    0.011    0.000    0.317    0.000 D:\Python_3.7.0\lib\encodings\cp1252.py:22(decode)
+  1000001    0.371    0.000    0.371    0.000 {method 'split' of 'str' objects}
+        1    1.845    1.845    2.919    2.919 good_perf_refact.py:8(analyze)
+        1    0.000    0.000    2.919    2.919 good_perf_refact.py:46(main)
+        1    0.000    0.000    2.921    2.921 good_perf_refact.py:4(<module>)
+      2/1    0.000    0.000    2.921    2.921 {built-in method builtins.exec}

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/pstatspoor.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/pstatspoor.txt
@@ -1,0 +1,152 @@
+
+profout% sort cumtime
+profout% reverse
+profout% stats
+Sun Feb 17 09:29:30 2019    profout
+
+         1087775 function calls (1087758 primitive calls) in 8.447 seconds
+
+   Ordered by: cumulative time
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:909(get_filename)
+        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:70(unix_dialect)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:65(excel_tab)
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:425(_check_tzinfo_arg)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:719(create_module)
+        3    0.000    0.000    0.000    0.000 {built-in method _imp.exec_builtin}
+        1    0.000    0.000    0.000    0.000 {method 'setter' of 'property' objects}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:131(DictWriter)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:55(excel)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:424(has_location)
+        2    0.000    0.000    0.000    0.000 {built-in method _imp.is_frozen}
+        6    0.000    0.000    0.000    0.000 {built-in method builtins.len}
+        2    0.000    0.000    0.000    0.000 {method 'endswith' of 'str' objects}
+        6    0.000    0.000    0.000    0.000 {built-in method nt.fspath}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:166(Sniffer)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:24(Dialect)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1081(tzinfo)
+        3    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:40(_days_before_year)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:765(is_package)
+       10    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:45(_days_in_month)
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
+        3    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:2117(_create)
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.acquire_lock}
+        4    0.000    0.000    0.000    0.000 {method 'rsplit' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:35(_new_module)
+       19    0.000    0.000    0.000    0.000 {built-in method _imp.release_lock}
+        6    0.000    0.000    0.000    0.000 {built-in method from_bytes}
+       20    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:321(<genexpr>)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:307(__init__)
+        2    0.000    0.000    0.000    0.000 {built-in method nt.getcwd}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:401(_check_name_wrapper)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:369(__init__)
+        2    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\codecs.py:260(__init__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:884(__init__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:855(__enter__)
+        9    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:859(__exit__)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:232(_requires_builtin_wrapper)
+        8    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:36(_relax_case)
+       19    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x00007FFEE8C88D30}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\csv.py:81(DictReader)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:416(parent)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:143(__init__)
+       22    0.000    0.000    0.000    0.000 {method 'rpartition' of 'str' objects}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:471(_validate_timestamp_pyc)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:748(exec_module)
+       44    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1151(time)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:773(date)
+        2    0.000    0.000    0.000    0.000 {built-in method _imp._fix_co_filename}
+        5    0.000    0.000    0.000    0.000 {built-in method _imp.is_builtin}
+        5    0.000    0.000    0.000    0.000 {built-in method builtins.any}
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1009(_handle_fromlist)
+        2    0.000    0.000    0.000    0.000 {built-in method _csv.reader}
+       84    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:176(cb)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:645(__neg__)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1488(datetime)
+        2    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1176(__new__)
+       45    0.000    0.000    0.000    0.000 {built-in method builtins.divmod}
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:408(_check_time_fields)
+        2    0.000    0.000    0.000    0.000 {built-in method _locale._getdefaultlocale}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:574(spec_from_file_location)
+       10    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1203(_path_importer_cache)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:103(release)
+       24    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:78(acquire)
+        9    0.000    0.000    0.000    0.000 {built-in method builtins.round}
+       31    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:62(_path_split)
+       45    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:222(_verbose_message)
+      171    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
+        3    0.000    0.000    0.000    0.000 {built-in method _csv.register_dialect}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:792(find_spec)
+       10    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:1351(_get_spec)
+        3    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:433(spec_from_loader)
+        2    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\_bootlocale.py:11(getpreferredencoding)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:318(__exit__)
+        3    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:1496(__new__)
+        2    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:803(__new__)
+       35    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:378(_check_int_field)
+        6    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:51(_r_long)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:58(__init__)
+        5    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:395(_check_date_fields)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:311(__enter__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:438(_classify_pyc)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:58(<listcomp>)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:369(_get_cached)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:719(find_spec)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:403(cached)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:2097(timezone)
+        4    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:271(cache_from_source)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:151(__exit__)
+        1    0.000    0.000    0.000    0.000 D:\Python_3.7.0\lib\datetime.py:453(timedelta)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:157(_get_module_lock)
+       40    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:56(_path_join)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:504(_init_module_attrs)
+        5    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:147(__enter__)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:951(path_stats)
+       72    0.000    0.000    0.000    0.000 {built-in method builtins.abs}
+       13    0.000    0.000    0.000    0.000 {built-in method builtins.__build_class__}
+        2    0.000    0.000    0.000    0.000 {built-in method now}
+        2    0.000    0.000    0.000    0.000 {built-in method builtins.print}
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:84(_path_is_mode_type)
+        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap_external>:93(_path_isfile)
+        2    0.001    0.000    0.001    0.000 {built-in method marshal.loads}
+        2    0.000    0.000    0.001    0.000 <frozen importlib._bootstrap_external>:523(_compile_bytecode)
+        2    0.001    0.000    0.001    0.000 {built-in method io.open}
+        8    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:1356(find_spec)
+       12    0.002    0.000    0.002    0.000 {built-in method nt.stat}
+       12    0.000    0.000    0.002    0.000 <frozen importlib._bootstrap_external>:74(_path_stat)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1240(_get_spec)
+        2    0.000    0.000    0.002    0.001 <frozen importlib._bootstrap_external>:1272(find_spec)
+        5    0.000    0.000    0.003    0.001 <frozen importlib._bootstrap>:882(_find_spec)
+        1    0.000    0.000    0.012    0.012 D:\Python_3.7.0\lib\csv.py:4(<module>)
+        3    0.013    0.004    0.013    0.004 {built-in method _imp.create_builtin}
+        3    0.000    0.000    0.013    0.004 <frozen importlib._bootstrap>:740(create_module)
+        5    0.000    0.000    0.013    0.003 <frozen importlib._bootstrap>:576(module_from_spec)
+        9    0.014    0.002    0.014    0.002 D:\Python_3.7.0\lib\datetime.py:472(__new__)
+        1    0.000    0.000    0.016    0.016 D:\Python_3.7.0\lib\datetime.py:5(<module>)
+        2    0.026    0.013    0.026    0.013 {method 'read' of '_io.FileIO' objects}
+      8/2    0.000    0.000    0.028    0.014 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
+        2    0.008    0.004    0.034    0.017 <frozen importlib._bootstrap_external>:914(get_data)
+        2    0.000    0.000    0.035    0.017 <frozen importlib._bootstrap_external>:793(get_code)
+        2    0.000    0.000    0.063    0.031 <frozen importlib._bootstrap_external>:722(exec_module)
+      5/2    0.000    0.000    0.063    0.032 <frozen importlib._bootstrap>:663(_load_unlocked)
+      5/2    0.000    0.000    0.066    0.033 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
+      5/2    0.000    0.000    0.066    0.033 <frozen importlib._bootstrap>:978(_find_and_load)
+  1000012    0.087    0.000    0.087    0.000 {method 'append' of 'list' objects}
+    43294    0.620    0.000    0.620    0.000 {built-in method _codecs.charmap_decode}
+    43294    0.022    0.000    0.642    0.000 D:\Python_3.7.0\lib\encodings\cp1252.py:22(decode)
+        1    7.562    7.562    8.292    8.292 poor_perf.py:9(analyze)
+        1    0.089    0.089    8.382    8.382 poor_perf.py:59(main)
+        1    0.000    0.000    8.447    8.447 poor_perf.py:4(<module>)
+      3/1    0.000    0.000    8.447    8.447 {built-in method builtins.exec}
+
+
+profout% quit
+Goodbye.

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/readme.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/readme.txt
@@ -1,0 +1,17 @@
+Explaination of submitted files:
+
+The following files are cProfile comparisons as I made changes to the original code and tested new ideas:
+
+cprofileresultpoor.txt
+cprofileresultgoodfirst.txt
+cprofileresultgoodsecond.txt
+cprofileresultgoodthird.txt
+cprofileresultgoodfourth.txt
+
+I had missed that 2018 was suppose to peg the 2017 count from the original poor file so I had to adjust my design and implemented a lambda to handle this specific case. 
+
+The file codecomparison.txt is a test of one code snippet change using just time stampstamps to compare the old code with the new code. The improvement was minimal between the two snippets.
+
+I tried pstat to get a more formatted comparison of the cprofiles between the poor and the latest version. These are in the files pstatspoor.txt and pstatsgoodrefact.txt.
+
+I used timeit to compare poor_perf with good_perf_refact and showed the result in the file timeitComparison.txt.

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/readme.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/readme.txt
@@ -8,7 +8,7 @@ cprofileresultgoodsecond.txt
 cprofileresultgoodthird.txt
 cprofileresultgoodfourth.txt
 
-I had missed that 2018 was suppose to peg the 2017 count from the original poor file so I had to adjust my design and implemented a lambda to handle this specific case. 
+I had missed that 2018 was suppose to peg the 2017 count from the original poor file so I had to adjust my design and implemented a lambda to handle this specific case. My new version had far more function calls in it but it was still faster. Iterating through the file and using strip() and split() were faster than using the csv.read. This is seen in cprofile third and fourth.
 
 The file codecomparison.txt is a test of one code snippet change using just time stampstamps to compare the old code with the new code. The improvement was minimal between the two snippets.
 

--- a/students/Shawn_DeGraw/lessons/lesson06/assignment/timeitComparison.txt
+++ b/students/Shawn_DeGraw/lessons/lesson06/assignment/timeitComparison.txt
@@ -1,0 +1,14 @@
+timeit result from original poor_perf:
+
+In [7]: timeit.timeit('poor_perf.analyze("data/exercise.csv")', globals = globals(), number=1)
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+Out[7]: 7.980007135000051
+
+
+timeit result from refactored good_perf_refact:
+
+In [4]: timeit.timeit('good_perf_refact.analyze("data/exercise.csv")', globals = globals(), number=1)
+{'2013': 5911, '2014': 5854, '2015': 5994, '2016': 5762, '2017': 11600, '2018': 0}
+'ao' was found 63395 times
+Out[4]: 2.4818834779998724


### PR DESCRIPTION
Contents of included readme.txt:

Explanation of submitted files:

The following files are cProfile comparisons as I made changes to the original code and tested new ideas:

cprofileresultpoor.txt
cprofileresultgoodfirst.txt
cprofileresultgoodsecond.txt
cprofileresultgoodthird.txt
cprofileresultgoodfourth.txt

I had missed that 2018 was suppose to peg the 2017 count from the original poor file so I had to adjust my design and implemented a lambda to handle this specific case. My new version had far more function calls in it but it was still faster. Iterating through the file and using strip() and split() were faster than using the csv.read. This is seen in cprofile third and fourth.

The file codecomparison.txt is a test of one code snippet change using just time stampstamps to compare the old code with the new code. The improvement was minimal between the two snippets.

I tried pstat to get a more formatted comparison of the cprofiles between the poor and the latest version. These are in the files pstatspoor.txt and pstatsgoodrefact.txt.

I used timeit to compare poor_perf with good_perf_refact and showed the result in the file timeitComparison.txt.